### PR TITLE
fix: position of input element is out of the screen area

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
@@ -122,6 +122,8 @@ namespace WebGLSupport
         [TooltipAttribute("show input element on canvas. this will make you select text by drag.")]
         public bool showHtmlElement = false;
 
+        private RectInt prevRect = new RectInt();
+        
         private IInputField Setup()
         {
             if (GetComponent<InputField>()) return new WrappedInputField(GetComponent<InputField>());
@@ -175,6 +177,12 @@ namespace WebGLSupport
             if (id != -1) throw new Exception("OnSelect : id != -1");
 
             var rect = GetElemetRect();
+
+            if (Mathf.Abs(rect.x) > Screen.width || Mathf.Abs(rect.y) > Screen.height)
+                rect = prevRect;
+            else 
+                prevRect = rect;
+            
             bool isPassword = input.contentType == ContentType.Password;
 
             var fontSize = Mathf.Max(14, input.fontSize); // limit font size : 14 !!


### PR DESCRIPTION
Sometimes application of the `camera.WorldToScreenPoint` in the `WebGLInput.cs` `GetScreenCoordinates()` method lead to very huge numbers, resulting that for `Canvas `with the `RenderMode.ScreenSpaceCamera` input field was shifted to far away.

I added simple bounds check. It is not ideal, but does the job.

Testable at https://github.com/decentraland/unity-renderer/pull/3426
Steps:
1. Teleport via chat /goto command to 100,100
2. Teleport back to 0,0
3. You should not see black screen blocking loading screen